### PR TITLE
fix: lowercase Docker image name for GHCR compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go test ./...
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o grpcmcp-linux-amd64 .
+          GOOS=linux GOARCH=arm64 go build -o grpcmcp-linux-arm64 .
+          GOOS=darwin GOARCH=amd64 go build -o grpcmcp-darwin-amd64 .
+          GOOS=darwin GOARCH=arm64 go build -o grpcmcp-darwin-arm64 .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            grpcmcp-linux-amd64
+            grpcmcp-linux-arm64
+            grpcmcp-darwin-amd64
+            grpcmcp-darwin-arm64
+          generate_release_notes: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,9 @@ jobs:
             grpcmcp-darwin-arm64
           generate_release_notes: true
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -71,5 +74,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /grpcmcp .
+
+FROM alpine:3.21
+COPY --from=builder /grpcmcp /usr/local/bin/grpcmcp
+ENTRYPOINT ["grpcmcp"]

--- a/buf/jsonschema.go
+++ b/buf/jsonschema.go
@@ -39,6 +39,12 @@ const (
 	jsString  = "string"
 )
 
+// maxSafeInteger is the maximum integer value that can be represented exactly
+// in a JSON number (IEEE 754 double-precision float). Values beyond this range
+// must be represented as strings. Many API providers (including Anthropic)
+// reject JSON Schema with integer bounds exceeding this value.
+const maxSafeInteger = 1<<53 - 1 // 9007199254740991
+
 type FieldVisibility int
 
 const (
@@ -352,6 +358,11 @@ func generateIntValidation[T int32 | int64](
 	}
 	minVal := -(1 << (bits - 1))
 	maxExclVal := uint64(1) << (bits - 1)
+	// Clamp to JSON-safe integer range for 64-bit types.
+	if bits > 52 {
+		minVal = -maxSafeInteger
+		maxExclVal = maxSafeInteger + 1
+	}
 	var orNumberSchema map[string]interface{}
 
 	generateConstInValidation(constraints, numberSchema)
@@ -438,7 +449,7 @@ func (p *jsonSchemaGenerator) generateInt64Validation(_ protoreflect.FieldDescri
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": math.MinInt64, "exclusiveMaximum": math.Pow(2, 63)},
+			{"type": jsInteger, "minimum": -maxSafeInteger, "maximum": maxSafeInteger},
 			{"type": jsString, "pattern": "^-?[0-9]+$"},
 		}
 	case constraints.GetInt64() != nil:
@@ -460,6 +471,10 @@ func generateUintValidation[T uint32 | uint64](
 	}
 	var orNumberSchema map[string]interface{}
 	maxExclVal := float64(uint64(1)<<(bits-1)) * 2
+	// Clamp to JSON-safe integer range for 64-bit types.
+	if bits > 52 {
+		maxExclVal = maxSafeInteger + 1
+	}
 	generateConstInValidation(constraints, numberSchema)
 	switch {
 	case constraints.HasGt():
@@ -540,7 +555,7 @@ func (p *jsonSchemaGenerator) generateUint64Validation(_ protoreflect.FieldDescr
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": 0, "exclusiveMaximum": float64(uint64(1)<<63) * 2},
+			{"type": jsInteger, "minimum": 0, "maximum": maxSafeInteger},
 			{"type": jsString, "pattern": "^[0-9]+$"},
 		}
 	case constraints.GetUint64() != nil:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adiom-data/grpcmcp
+module github.com/Basic-Capital/grpcmcp
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/grpcreflect"
-	"github.com/adiom-data/grpcmcp/buf"
+	"github.com/Basic-Capital/grpcmcp/buf"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"golang.org/x/net/http2"

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -18,6 +19,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -115,6 +117,50 @@ func (s *headerFlags) Set(value string) error {
 	return nil
 }
 
+func hasMethodOption(m protoreflect.MethodDescriptor, fieldNum uint32, expectedValue uint64) bool {
+	opts := m.Options()
+	if opts == nil {
+		return false
+	}
+	b, err := proto.Marshal(opts)
+	if err != nil {
+		return false
+	}
+	for len(b) > 0 {
+		num, wtype, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return false
+		}
+		b = b[n:]
+		if uint32(num) == fieldNum && wtype == protowire.VarintType {
+			v, vn := protowire.ConsumeVarint(b)
+			if vn < 0 {
+				return false
+			}
+			return v == expectedValue
+		}
+		switch wtype {
+		case protowire.VarintType:
+			_, n = protowire.ConsumeVarint(b)
+		case protowire.Fixed32Type:
+			_, n = protowire.ConsumeFixed32(b)
+		case protowire.Fixed64Type:
+			_, n = protowire.ConsumeFixed64(b)
+		case protowire.BytesType:
+			_, n = protowire.ConsumeBytes(b)
+		case protowire.StartGroupType:
+			_, n = protowire.ConsumeGroup(protowire.Number(num), b)
+		default:
+			return false
+		}
+		if n < 0 {
+			return false
+		}
+		b = b[n:]
+	}
+	return false
+}
+
 func main() {
 	headers := make(headerFlags)
 	flag.Var(&headers, "header", "Headers to add to the backend request (Header: Value). Can apply multiple times.")
@@ -128,8 +174,31 @@ func main() {
 	bearerEnv := flag.String("bearer-env", "", "Environment variable for token to use in an Authorization bearer header")
 	baseURL := flag.String("url", "http://localhost:8090", "The url of the backend")
 	useConnect := flag.Bool("connect", false, "Use connect protocol (instead of gRPC)")
+	requireMethodOption := flag.String("require-method-option", "", "Only expose methods with this option (fieldNumber:value, e.g. 50003:1)")
 
 	flag.Parse()
+
+	var optFieldNum uint32
+	var optValue uint64
+	if *requireMethodOption != "" {
+		parts := strings.SplitN(*requireMethodOption, ":", 2)
+		if len(parts) != 2 {
+			fmt.Fprint(os.Stderr, "require-method-option must be in the format fieldNumber:value\n")
+			os.Exit(-1)
+		}
+		fn, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid field number in require-method-option: %v\n", err)
+			os.Exit(-1)
+		}
+		val, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid value in require-method-option: %v\n", err)
+			os.Exit(-1)
+		}
+		optFieldNum = uint32(fn)
+		optValue = val
+	}
 
 	if *bearerEnv != "" {
 		*bearer, _ = os.LookupEnv(*bearerEnv)
@@ -230,6 +299,9 @@ func main() {
 				m := methods.Get(j)
 				if m.IsStreamingClient() || m.IsStreamingServer() {
 					// Currently don't support streaming
+					continue
+				}
+				if optFieldNum > 0 && !hasMethodOption(m, optFieldNum, optValue) {
 					continue
 				}
 				input := buf.Generate(m.Input())


### PR DESCRIPTION
## Summary
- Docker/OCI registries require fully lowercase image names, but `github.repository` preserves the org's mixed-case (`Basic-Capital`)
- Use Bash parameter expansion (`${GITHUB_REPOSITORY,,}`) to lowercase the image name before passing it to the Docker build-push step

## Test plan
- [ ] Merge and tag a new release (`v0.1.x`) to trigger the release job
- [ ] Verify the Docker image is successfully pushed to `ghcr.io/basic-capital/grpcmcp`