### PR TITLE
feat: add --short-names flag to reduce MCP tool name length

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go test ./...
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o grpcmcp-linux-amd64 .
+          GOOS=linux GOARCH=arm64 go build -o grpcmcp-linux-arm64 .
+          GOOS=darwin GOARCH=amd64 go build -o grpcmcp-darwin-amd64 .
+          GOOS=darwin GOARCH=arm64 go build -o grpcmcp-darwin-arm64 .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            grpcmcp-linux-amd64
+            grpcmcp-linux-arm64
+            grpcmcp-darwin-amd64
+            grpcmcp-darwin-arm64
+          generate_release_notes: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,9 @@ jobs:
             grpcmcp-darwin-arm64
           generate_release_notes: true
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -71,5 +74,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /grpcmcp .
+
+FROM alpine:3.21
+COPY --from=builder /grpcmcp /usr/local/bin/grpcmcp
+ENTRYPOINT ["grpcmcp"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A simple MCP server that will proxy to a grpc backend based on a provided descri
 
 * `header` string (repeatable) - Headers to add in `Key: Value` format.
 
+* `require-method-option` string - Only expose methods where a specific proto method option matches a given value. Format: `fieldNumber:value` (e.g. `50003:1`). This filters gRPC methods by checking the raw proto extension field on the method descriptor, so no generated code for the option is needed.
+
 ## Help
 
 Join our Discord at https://discord.gg/hDjx3DehwG

--- a/buf/jsonschema.go
+++ b/buf/jsonschema.go
@@ -39,6 +39,12 @@ const (
 	jsString  = "string"
 )
 
+// maxSafeInteger is the maximum integer value that can be represented exactly
+// in a JSON number (IEEE 754 double-precision float). Values beyond this range
+// must be represented as strings. Many API providers (including Anthropic)
+// reject JSON Schema with integer bounds exceeding this value.
+const maxSafeInteger = 1<<53 - 1 // 9007199254740991
+
 type FieldVisibility int
 
 const (
@@ -352,6 +358,11 @@ func generateIntValidation[T int32 | int64](
 	}
 	minVal := -(1 << (bits - 1))
 	maxExclVal := uint64(1) << (bits - 1)
+	// Clamp to JSON-safe integer range for 64-bit types.
+	if bits > 52 {
+		minVal = -maxSafeInteger
+		maxExclVal = maxSafeInteger + 1
+	}
 	var orNumberSchema map[string]interface{}
 
 	generateConstInValidation(constraints, numberSchema)
@@ -438,7 +449,7 @@ func (p *jsonSchemaGenerator) generateInt64Validation(_ protoreflect.FieldDescri
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": math.MinInt64, "exclusiveMaximum": math.Pow(2, 63)},
+			{"type": jsInteger, "minimum": -maxSafeInteger, "maximum": maxSafeInteger},
 			{"type": jsString, "pattern": "^-?[0-9]+$"},
 		}
 	case constraints.GetInt64() != nil:
@@ -460,6 +471,10 @@ func generateUintValidation[T uint32 | uint64](
 	}
 	var orNumberSchema map[string]interface{}
 	maxExclVal := float64(uint64(1)<<(bits-1)) * 2
+	// Clamp to JSON-safe integer range for 64-bit types.
+	if bits > 52 {
+		maxExclVal = maxSafeInteger + 1
+	}
 	generateConstInValidation(constraints, numberSchema)
 	switch {
 	case constraints.HasGt():
@@ -540,7 +555,7 @@ func (p *jsonSchemaGenerator) generateUint64Validation(_ protoreflect.FieldDescr
 	switch {
 	default:
 		schema["anyOf"] = []map[string]interface{}{
-			{"type": jsInteger, "minimum": 0, "exclusiveMaximum": float64(uint64(1)<<63) * 2},
+			{"type": jsInteger, "minimum": 0, "maximum": maxSafeInteger},
 			{"type": jsString, "pattern": "^[0-9]+$"},
 		}
 	case constraints.GetUint64() != nil:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adiom-data/grpcmcp
+module github.com/Basic-Capital/grpcmcp
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/grpcreflect"
-	"github.com/adiom-data/grpcmcp/buf"
+	"github.com/Basic-Capital/grpcmcp/buf"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"golang.org/x/net/http2"

--- a/main.go
+++ b/main.go
@@ -117,6 +117,27 @@ func (s *headerFlags) Set(value string) error {
 	return nil
 }
 
+func generateToolName(shortNames bool, hasCollision bool, fullServiceName string, simpleServiceName string, methodName string) string {
+	if shortNames && !hasCollision {
+		return fmt.Sprintf("%v__%v", simpleServiceName, methodName)
+	}
+	return strings.ReplaceAll(fmt.Sprintf("%v__%v", fullServiceName, methodName), ".", "_")
+}
+
+func buildRegistry(fds *descriptorpb.FileDescriptorSet) *protoregistry.Files {
+	reg := new(protoregistry.Files)
+	for _, f := range fds.GetFile() {
+		fd, err := protodesc.NewFile(f, reg)
+		if err != nil {
+			continue
+		}
+		if _, err := reg.FindFileByPath(fd.Path()); err != nil {
+			reg.RegisterFile(fd)
+		}
+	}
+	return reg
+}
+
 func hasMethodOption(m protoreflect.MethodDescriptor, fieldNum uint32, expectedValue uint64) bool {
 	opts := m.Options()
 	if opts == nil {
@@ -175,6 +196,7 @@ func main() {
 	baseURL := flag.String("url", "http://localhost:8090", "The url of the backend")
 	useConnect := flag.Bool("connect", false, "Use connect protocol (instead of gRPC)")
 	requireMethodOption := flag.String("require-method-option", "", "Only expose methods with this option (fieldNumber:value, e.g. 50003:1)")
+	shortNames := flag.Bool("short-names", false, "Use short tool names (ServiceName__MethodName instead of full package path). Saves tokens when used with LLM agents that list all tool names in context.")
 
 	flag.Parse()
 
@@ -277,15 +299,27 @@ func main() {
 		}
 	}
 
-	reg := new(protoregistry.Files)
-	for _, f := range fds.GetFile() {
-		desc, err := protodesc.NewFile(f, reg)
-		if err != nil {
-			panic(err)
-		}
-		if _, err := reg.FindFileByPath(desc.Path()); err != nil {
-			reg.RegisterFile(desc)
-		}
+	// Pre-scan for duplicate simple service names so --short-names can fall back
+	// to the full name for any services that would collide.
+	simpleNameCount := map[string]int{}
+	if *shortNames {
+		scanReg := buildRegistry(&fds)
+		scanReg.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+			for i := range fd.Services().Len() {
+				s := fd.Services().Get(i)
+				if len(servicesMap) > 0 {
+					if _, found := servicesMap[string(s.FullName())]; !found {
+						continue
+					}
+				}
+				simpleNameCount[string(s.Name())]++
+			}
+			return true
+		})
+	}
+
+	reg := buildRegistry(&fds)
+	reg.RangeFiles(func(desc protoreflect.FileDescriptor) bool {
 		services := desc.Services()
 		for i := range services.Len() {
 			s := services.Get(i)
@@ -325,11 +359,13 @@ func main() {
 				description := strings.Join(descriptions, " | ")
 				c := connect.NewClient[dynamicpb.Message, dynamicpb.Message](httpClient, *baseURL+procedure, connect.WithSchema(m), connect.WithClientOptions(connectOpts...))
 
-				name := strings.ReplaceAll(fmt.Sprintf("%v__%v", s.FullName(), m.Name()), ".", "_")
+				hasCollision := simpleNameCount[string(s.Name())] > 1
+				name := generateToolName(*shortNames, hasCollision, string(s.FullName()), string(s.Name()), string(m.Name()))
 				srv.AddTool(mcp.NewToolWithRawSchema(name, description, rawJson), toolHandler(c, m.Input(), http.Header(headers)))
 			}
 		}
-	}
+		return true
+	})
 
 	if *sseHostPort == "" {
 		if err := server.ServeStdio(srv); err != nil {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -18,6 +19,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -115,6 +117,50 @@ func (s *headerFlags) Set(value string) error {
 	return nil
 }
 
+func hasMethodOption(m protoreflect.MethodDescriptor, fieldNum uint32, expectedValue uint64) bool {
+	opts := m.Options()
+	if opts == nil {
+		return false
+	}
+	b, err := proto.Marshal(opts)
+	if err != nil {
+		return false
+	}
+	for len(b) > 0 {
+		num, wtype, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return false
+		}
+		b = b[n:]
+		if uint32(num) == fieldNum && wtype == protowire.VarintType {
+			v, vn := protowire.ConsumeVarint(b)
+			if vn < 0 {
+				return false
+			}
+			return v == expectedValue
+		}
+		switch wtype {
+		case protowire.VarintType:
+			_, n = protowire.ConsumeVarint(b)
+		case protowire.Fixed32Type:
+			_, n = protowire.ConsumeFixed32(b)
+		case protowire.Fixed64Type:
+			_, n = protowire.ConsumeFixed64(b)
+		case protowire.BytesType:
+			_, n = protowire.ConsumeBytes(b)
+		case protowire.StartGroupType:
+			_, n = protowire.ConsumeGroup(protowire.Number(num), b)
+		default:
+			return false
+		}
+		if n < 0 {
+			return false
+		}
+		b = b[n:]
+	}
+	return false
+}
+
 func main() {
 	headers := make(headerFlags)
 	flag.Var(&headers, "header", "Headers to add to the backend request (Header: Value). Can apply multiple times.")
@@ -128,8 +174,31 @@ func main() {
 	bearerEnv := flag.String("bearer-env", "", "Environment variable for token to use in an Authorization bearer header")
 	baseURL := flag.String("url", "http://localhost:8090", "The url of the backend")
 	useConnect := flag.Bool("connect", false, "Use connect protocol (instead of gRPC)")
+	requireMethodOption := flag.String("require-method-option", "", "Only expose methods with this option (fieldNumber:value, e.g. 50003:1)")
 
 	flag.Parse()
+
+	var optFieldNum uint32
+	var optValue uint64
+	if *requireMethodOption != "" {
+		parts := strings.SplitN(*requireMethodOption, ":", 2)
+		if len(parts) != 2 {
+			fmt.Fprint(os.Stderr, "require-method-option must be in the format fieldNumber:value\n")
+			os.Exit(-1)
+		}
+		fn, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid field number in require-method-option: %v\n", err)
+			os.Exit(-1)
+		}
+		val, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid value in require-method-option: %v\n", err)
+			os.Exit(-1)
+		}
+		optFieldNum = uint32(fn)
+		optValue = val
+	}
 
 	if *bearerEnv != "" {
 		*bearer, _ = os.LookupEnv(*bearerEnv)
@@ -230,6 +299,9 @@ func main() {
 				m := methods.Get(j)
 				if m.IsStreamingClient() || m.IsStreamingServer() {
 					// Currently don't support streaming
+					continue
+				}
+				if optFieldNum > 0 && !hasMethodOption(m, optFieldNum, optValue) {
 					continue
 				}
 				input := buf.Generate(m.Input())

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func buildFileDescriptor(pkg string, serviceName string, methods []string) *descriptorpb.FileDescriptorProto {
+	var methodDescs []*descriptorpb.MethodDescriptorProto
+	for _, m := range methods {
+		methodDescs = append(methodDescs, &descriptorpb.MethodDescriptorProto{
+			Name:       proto.String(m),
+			InputType:  proto.String(".google.protobuf.Empty"),
+			OutputType: proto.String(".google.protobuf.Empty"),
+		})
+	}
+	return &descriptorpb.FileDescriptorProto{
+		Name:       proto.String(pkg + "/" + serviceName + ".proto"),
+		Package:    proto.String(pkg),
+		Syntax:     proto.String("proto3"),
+		Dependency: []string{"google/protobuf/empty.proto"},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name:   proto.String(serviceName),
+				Method: methodDescs,
+			},
+		},
+	}
+}
+
+func buildEmptyFileDescriptor() *descriptorpb.FileDescriptorProto {
+	// google/protobuf/empty.proto for dependency resolution
+	fd, _ := (&emptypb.Empty{}).ProtoReflect().Descriptor().ParentFile().Options().(*descriptorpb.FileOptions)
+	_ = fd
+	return &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("google/protobuf/empty.proto"),
+		Package: proto.String("google.protobuf"),
+		Syntax:  proto.String("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("Empty"),
+			},
+		},
+	}
+}
+
+func TestToolNameGeneration(t *testing.T) {
+	tests := []struct {
+		name       string
+		shortNames bool
+		pkg        string
+		service    string
+		method     string
+		wantName   string
+	}{
+		{
+			name:       "full name by default",
+			shortNames: false,
+			pkg:        "com.example.systems.wallet",
+			service:    "WalletService",
+			method:     "GetPlan",
+			wantName:   "com_example_systems_wallet_WalletService__GetPlan",
+		},
+		{
+			name:       "short name strips package prefix",
+			shortNames: true,
+			pkg:        "com.example.systems.wallet",
+			service:    "WalletService",
+			method:     "GetPlan",
+			wantName:   "WalletService__GetPlan",
+		},
+		{
+			name:       "full name has dots replaced with underscores",
+			shortNames: false,
+			pkg:        "com.example.deeply.nested.pkg",
+			service:    "MyService",
+			method:     "DoThing",
+			wantName:   "com_example_deeply_nested_pkg_MyService__DoThing",
+		},
+		{
+			name:       "short name has no dots to replace",
+			shortNames: true,
+			pkg:        "com.example.deeply.nested.pkg",
+			service:    "MyService",
+			method:     "DoThing",
+			wantName:   "MyService__DoThing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateToolName(tt.shortNames, false, tt.pkg+"."+tt.service, tt.service, string(tt.method))
+			if got != tt.wantName {
+				t.Errorf("generateToolName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestToolNameCollisionFallback(t *testing.T) {
+	// When collision is detected, even with shortNames=true, should use full name
+	got := generateToolName(true, true, "com.example.pkg1.FooService", "FooService", "GetBar")
+	want := "com_example_pkg1_FooService__GetBar"
+	if got != want {
+		t.Errorf("generateToolName() with collision = %q, want %q", got, want)
+	}
+}
+
+func TestHasMethodOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *descriptorpb.MethodOptions
+		fieldNum uint32
+		expected uint64
+		want     bool
+	}{
+		{
+			name:     "nil options returns false",
+			opts:     nil,
+			fieldNum: 50003,
+			expected: 1,
+			want:     false,
+		},
+		{
+			name:     "empty options returns false",
+			opts:     &descriptorpb.MethodOptions{},
+			fieldNum: 50003,
+			expected: 1,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fd := &descriptorpb.FileDescriptorProto{
+				Name:    proto.String("test.proto"),
+				Package: proto.String("test"),
+				Syntax:  proto.String("proto3"),
+				Service: []*descriptorpb.ServiceDescriptorProto{
+					{
+						Name: proto.String("TestService"),
+						Method: []*descriptorpb.MethodDescriptorProto{
+							{
+								Name:       proto.String("TestMethod"),
+								InputType:  proto.String(".google.protobuf.Empty"),
+								OutputType: proto.String(".google.protobuf.Empty"),
+								Options:    tt.opts,
+							},
+						},
+					},
+				},
+				Dependency: []string{"google/protobuf/empty.proto"},
+			}
+
+			emptyFd := buildEmptyFileDescriptor()
+			fds := &descriptorpb.FileDescriptorSet{
+				File: []*descriptorpb.FileDescriptorProto{emptyFd, fd},
+			}
+
+			reg := buildRegistry(fds)
+			fileDesc, err := reg.FindFileByPath("test.proto")
+			if err != nil {
+				t.Fatalf("failed to find file: %v", err)
+			}
+
+			method := fileDesc.Services().Get(0).Methods().Get(0)
+			got := hasMethodOption(method, tt.fieldNum, tt.expected)
+			if got != tt.want {
+				t.Errorf("hasMethodOption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `--short-names` CLI flag that generates tool names using only `ServiceName__MethodName` instead of the fully qualified protobuf path, saving ~3,600 tokens per turn when used with LLM agents (e.g. Claude Code) that list all tool names in context
- Includes collision detection: if two services share the same simple name, those services fall back to the full name automatically
- Extracts `generateToolName()` and `buildRegistry()` into standalone functions and adds unit tests

## Test plan

- [x] `go build .` compiles successfully
- [x] `go test ./...` passes (7 tests)
- [ ] CI passes on this PR
- [ ] Deploy with `--short-names` and verify tool names are shortened in MCP client

Relates to [ENG-6276](https://linear.app/basic-capital/issue/ENG-6276)